### PR TITLE
[android-security-13.0.0_r9] Fix Segv on unknown address error flagged by fuzzer test.

### DIFF
--- a/media/mtp/MtpProperty.h
+++ b/media/mtp/MtpProperty.h
@@ -26,6 +26,9 @@ namespace android {
 class MtpDataPacket;
 
 struct MtpPropertyValue {
+    // pointer str initialized to NULL so that free operation
+    // is not called for pre-assigned value
+    MtpPropertyValue() : str (NULL) {}
     union {
         int8_t          i8;
         uint8_t         u8;


### PR DESCRIPTION
The error is thrown when the destructor tries to free pointer memory. This is happening for cases where the pointer was not initialized. Initializing it to a default value fixes the error.

Bug: 245135112
Test: Build mtp_host_property_fuzzer and run on the target device (cherry picked from commit 3afa6e80e8568fe63f893fa354bc79ef91d3dcc0) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:99d0823ca2b8275f000a437150fb8d1938b1b31a) Merged-In: I255cd68b7641e96ac47ab81479b9b46b78c15580 Change-Id: I255cd68b7641e96ac47ab81479b9b46b78c15580