### PR TITLE
don't require RECORD_AUDIO permission for REMOTE_SUBMIX audio source

### DIFF
--- a/media/utils/ServiceUtilities.cpp
+++ b/media/utils/ServiceUtilities.cpp
@@ -141,15 +141,18 @@ std::optional<AttributionSourceState> resolveAttributionSource(
 
     const int32_t attributedOpCode = getOpForSource(source);
 
+    auto permission = source == AUDIO_SOURCE_REMOTE_SUBMIX ?
+            sModifyAudioRouting : sAndroidPermissionRecordAudio;
+
     permission::PermissionChecker permissionChecker;
     int permitted;
     if (start) {
         permitted = permissionChecker.checkPermissionForStartDataDeliveryFromDatasource(
-                sAndroidPermissionRecordAudio, resolvedAttributionSource.value(), msg,
+                permission, resolvedAttributionSource.value(), msg,
                 attributedOpCode);
     } else {
         permitted = permissionChecker.checkPermissionForPreflightFromDatasource(
-                sAndroidPermissionRecordAudio, resolvedAttributionSource.value(), msg,
+                permission, resolvedAttributionSource.value(), msg,
                 attributedOpCode);
     }
 


### PR DESCRIPTION
RECORD_AUDIO wasn't required before Android 15 QPR1, MODIFY_AUDIO_ROUTING permission was enough.

REMOTE_SUBMIX audio source is used by Android Auto to reroute audio output to the car.

Depends on:
https://github.com/GrapheneOS/platform_manifest/pull/61
https://github.com/GrapheneOS/script/pull/81