### PR TITLE
allow MODIFY_AUDIO_ROUTING holders to access REMOTE_SUBMIX audio source 

### DIFF
--- a/media/utils/ServiceUtilities.cpp
+++ b/media/utils/ServiceUtilities.cpp
@@ -152,6 +152,17 @@ std::optional<AttributionSourceState> resolveAttributionSource(
                 sAndroidPermissionRecordAudio, resolvedAttributionSource.value(), msg,
                 attributedOpCode);
     }
+    if (source == AUDIO_SOURCE_REMOTE_SUBMIX && permitted != permission::PermissionChecker::PERMISSION_GRANTED) {
+        if (start) {
+            permitted = permissionChecker.checkPermissionForStartDataDeliveryFromDatasource(
+                    sModifyAudioRouting, resolvedAttributionSource.value(), msg,
+                    attributedOpCode);
+        } else {
+            permitted = permissionChecker.checkPermissionForPreflightFromDatasource(
+                    sModifyAudioRouting, resolvedAttributionSource.value(), msg,
+                    attributedOpCode);
+        }
+    }
 
     return permitted;
 }

--- a/media/utils/ServiceUtilities.cpp
+++ b/media/utils/ServiceUtilities.cpp
@@ -141,18 +141,15 @@ std::optional<AttributionSourceState> resolveAttributionSource(
 
     const int32_t attributedOpCode = getOpForSource(source);
 
-    auto permission = source == AUDIO_SOURCE_REMOTE_SUBMIX ?
-            sModifyAudioRouting : sAndroidPermissionRecordAudio;
-
     permission::PermissionChecker permissionChecker;
     int permitted;
     if (start) {
         permitted = permissionChecker.checkPermissionForStartDataDeliveryFromDatasource(
-                permission, resolvedAttributionSource.value(), msg,
+                sAndroidPermissionRecordAudio, resolvedAttributionSource.value(), msg,
                 attributedOpCode);
     } else {
         permitted = permissionChecker.checkPermissionForPreflightFromDatasource(
-                permission, resolvedAttributionSource.value(), msg,
+                sAndroidPermissionRecordAudio, resolvedAttributionSource.value(), msg,
                 attributedOpCode);
     }
 


### PR DESCRIPTION
RECORD_AUDIO permission wasn't required before Android 15 QPR1, MODIFY_AUDIO_ROUTING permission was
enough.

REMOTE_SUBMIX audio source is used by Android Auto to reroute audio output to the car.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4614