### PR TITLE
C2SoftDav1dDec: configure decoder to output only one layer in SVC mode

### DIFF
--- a/media/codec2/components/dav1d/C2SoftDav1dDec.cpp
+++ b/media/codec2/components/dav1d/C2SoftDav1dDec.cpp
@@ -547,6 +547,7 @@ bool C2SoftDav1dDec::initDecoder() {
 
     Dav1dSettings lib_settings;
     dav1d_default_settings(&lib_settings);
+    lib_settings.all_layers = 0;
     int cpu_count = GetCPUCoreCount();
     lib_settings.n_threads = std::max(cpu_count / 2, 1);  // use up to half the cores by default.
 


### PR DESCRIPTION
dav1d default settings are configured to output all layers for svc clips. The plugin is not designed to handle this. Disable outputting all layers buffers

Bug: 424384335
Bug: 427113482
Test: Manual
Flag: EXEMPT bugfix
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:ba571df05a6e65545dbda4c9988c2bc23aae8f16) Cherrypick-From: https://googleplex-android-review.googlesource.com/q/commit:ea4bc6759153ef0ceadc7a802bad4b50d8012ba3 Merged-In: I829e2cc4da755a713c6d0994771fc269d47bbbb5 Change-Id: I829e2cc4da755a713c6d0994771fc269d47bbbb5