### PR TITLE
media: use absolute media profile XML paths

### DIFF
--- a/media/libmedia/MediaProfiles.cpp
+++ b/media/libmedia/MediaProfiles.cpp
@@ -49,10 +49,10 @@ std::array<char const*, 5> const& getXmlPaths() {
         []() -> decltype(paths) {
             // Directories for XML file that will be searched (in this order).
             constexpr std::array<char const*, 4> searchDirs = {
-                "product/etc/",
-                "odm/etc/",
-                "vendor/etc/",
-                "system/etc/",
+                "/product/etc/",
+                "/odm/etc/",
+                "/vendor/etc/",
+                "/system/etc/",
             };
 
             // The file name may contain a variant if the vendor property
@@ -69,7 +69,7 @@ std::array<char const*, 5> const& getXmlPaths() {
                      searchDirs[1] + fileName,
                      searchDirs[2] + fileName,
                      searchDirs[3] + fileName,
-                     "system/etc/media_profiles.xml" // System fallback
+                     "/system/etc/media_profiles.xml" // System fallback
                    };
         }();
     static std::array<char const*, 5> const cPaths = {


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6349
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8110

MediaProfiles searches for the device media_profiles XML with paths such as vendor/etc. Those paths are resolved against the process cwd because checkXmlFile() uses stat() directly.

That works when the singleton is initialized from a process with cwd /, but it is not a valid assumption for app processes. With exec-based app spawning, CamcorderProfile can be initialized inside the app after native code has changed cwd, causing the XML lookup to miss the device file and cache the default MediaProfiles instance for the process lifetime.

For example, in WhatsApp, these logs can be found:

    W MediaProfiles: Could not find a validated xml file. Using the default instance instead.
    E MediaProfiles: The given camcorder profile camera 1 quality 1 is not found

Native code in WhatsApp changes the cwd (from `UnfinishedCallEventUploader` -> `Java_com_whatsapp_calling_voipcalling_Voip_getUnfinishedCallEvent`) and never changes it back:

    stallion:/ # readlink /proc/<WhatsApp PID>/cwd
    /data/data/com.whatsapp/cache/voip

The system zygote, at cwd /, runs preloadClasses() which initializes android.media.CamcorderProfile and loads MediaProfiles from the correct path; exec-spawned apps skip preloadClasses(), so MediaProfiles lazy loads at whatever cwd was reached and persists any bad results

Use absolute partition paths for the normal media_profiles search. This matches the VTS validator's lookup model and makes CamcorderProfile independent of the caller process cwd.

Test: manual, WhatsApp front video camera working with exec spawning
Test: atest vts_mediaProfiles_validate_test
Test: atest CtsMediaMiscTestCases:android.media.misc.cts.CamcorderProfileTest
Test: atest CtsCameraTestCases:android.hardware.camera2.cts.RecordingTest
Test: atest CtsCameraTestCases:android.hardware.camera2.cts.ExtendedCameraCharacteristicsTest